### PR TITLE
Replacing incorrect tech level

### DIFF
--- a/Defs/ResearchProjectDefs/RimWriter_ResearchProjects.xml
+++ b/Defs/ResearchProjectDefs/RimWriter_ResearchProjects.xml
@@ -46,7 +46,7 @@ Y
     <label>bookshelves</label>
     <description>Allows your colony to construct shelves for scrolls, journals, and books.</description>
     <baseCost>50</baseCost>
-    <techLevel>Neolithic</techLevel>
+    <techLevel>Medieval</techLevel>
     <prerequisites>
       <li>RimWriter_TechPrimitiveWriting</li>
       <li>ComplexFurniture</li>


### PR DESCRIPTION
Complex Furniture has a tech level of medieval, yet bookshelves (using complex furniture as a prerequisite) have a tech-level of Neolithic. This causes research tree mods to throw warnings.